### PR TITLE
Allow parser to accept all commands

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,7 +6,7 @@ from router import Router
 def main():
     parser = Parser()
     try:
-        command_list = parser.parse(sys.argv[1:])
+        command_list = parser.parse()
     except Parser.ParserException as e:
         sys.exit(e)
 

--- a/parser.py
+++ b/parser.py
@@ -1,4 +1,4 @@
-from argparse import ArgumentParser
+import argparse
 from git_undo_exception import GitUndoException
 
 
@@ -8,18 +8,18 @@ class Parser:
         pass
 
     def __init__(self):
-        self.parser = ArgumentParser(
+        self.parser = argparse.ArgumentParser(
             description=(
                 'Wrapper utility around Git to provide undo/redo functions.'
             ),
         )
-        self.parser.add_argument('command', nargs='*')
+        self.parser.add_argument('command', nargs=argparse.REMAINDER)
         ''' TODO: Optional arguments we can pass in:
             Example: Dry-run
         '''
 
-    def parse(self, data):
-        _dict = vars(self.parser.parse_args(data))
+    def parse(self):
+        _dict = vars(self.parser.parse_args())
         command_list = _dict['command']
         if len(command_list) == 0:
             raise Parser.ParserException('Command not supplied.')


### PR DESCRIPTION
- Before, the parser will accidentally try to recognize '-m' as an argument to the program.
- And then BAM, here is the fix.
