### PR TITLE
Forward commands to git

### DIFF
--- a/git_runner.py
+++ b/git_runner.py
@@ -10,3 +10,11 @@ class GitRunner:
         if command_list[0] == 'commit':
             self.timeline.add(command_list)
 
+        self.forward_command(command_list)
+
+    def forward_command(self, command_list):
+        command_list.insert(0, 'git')
+        output = pexpect.run(' '.join(command_list))
+        if output:
+            print output
+


### PR DESCRIPTION
2 bugs that need to be fixed:
1. Quotations get stripped from shell and not passed to python.
   ie: git commit -m "commit message" gets parsed as
   ['git', 'commit' '-m', 'commit message']
2. Commands that open a text editor do not work.
   ie: git commit
   For me, it should open vim. But it just hangs

@davidozhang  said he might have a fix for these
