### PR TITLE
Install/alias script for homebrew

### DIFF
--- a/git-undo.sh
+++ b/git-undo.sh
@@ -1,0 +1,2 @@
+#!/bin/sh
+echo "alias git=python main.py" > .bashrc


### PR DESCRIPTION
Simply aliases `git` with `python main.py`. Once integrated in a newer release we'll be able (hopefully) run the next two commands to install the wrapper. Need to test and update url of brew formula once added.

```
brew tap ldreyes/tap
brew install git-undo
```
